### PR TITLE
[feat] Splash 화면 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,4 +61,7 @@ dependencies {
 
     // KAKAO LOGIN API
     implementation "com.kakao.sdk:v2-user:2.15.0" // 카카오 로그인
+
+    // Splash Screen
+    implementation 'androidx.core:core-splashscreen:1.0.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,9 +19,14 @@
         tools:targetApi="31">
         <activity
             android:name=".src.ui.view.SplashActivity"
-            android:theme="@style/SplashScreen"
-            android:exported="true" />
-         <activity
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".src.ui.view.LoginActivity"
             android:exported="true" >
             <intent-filter>
@@ -33,12 +38,6 @@
                 <data android:host="oauth"
                     android:scheme="kakaofb5550ba69a57eb73aae78bc996d8a8e" />
             </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
 
         <activity
@@ -49,9 +48,6 @@
             android:exported="false" />
         <activity
             android:name=".src.ui.view.VeganTestActivity"
-            android:exported="false" />
-        <activity
-            android:name=".src.ui.view.LoginActivity"
             android:exported="false" />
         <activity
             android:name=".src.ui.view.VeganMapActivity"

--- a/app/src/main/java/com/example/beginvegan/src/ui/view/SplashActivity.kt
+++ b/app/src/main/java/com/example/beginvegan/src/ui/view/SplashActivity.kt
@@ -3,15 +3,21 @@ package com.example.beginvegan.src.ui.view
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.os.Handler
 import com.example.beginvegan.R
+import com.example.beginvegan.config.BaseActivity
+import com.example.beginvegan.databinding.ActivitySplashBinding
 
-class  SplashActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+class  SplashActivity : BaseActivity<ActivitySplashBinding>({ActivitySplashBinding.inflate(it)}){
+    override fun init() {
+        Handler(mainLooper).postDelayed({
+            moveToLogin()
 
-        val intent = Intent(this,MainActivity::class.java)
+        },3000)
+    }
+    private fun moveToLogin(){
+        val intent = Intent(this,LoginActivity::class.java)
         startActivity(intent)
-
-        finish( )
+        finish()
     }
 }

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -5,17 +5,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".src.ui.view.SplashActivity">
-<!--    이후 삭제 가능성-->
-<!--    <ImageView-->
-<!--        android:id="@+id/iv_splash_logo"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="0dp"-->
-<!--        android:src="@drawable/logo_beginvegan"-->
-<!--        app:layout_constraintTop_toTopOf="parent"-->
-<!--        app:layout_constraintEnd_toEndOf="parent"-->
-<!--        app:layout_constraintStart_toStartOf="parent"-->
-<!--        app:layout_constraintBottom_toBottomOf="parent"-->
-<!--        android:layout_marginHorizontal="128dp"-->
-<!--        android:layout_marginTop="304dp"-->
-<!--        android:scaleType="fitStart"/>-->
+    <ImageView
+        android:id="@+id/iv_splash_logo"
+        android:layout_width="104dp"
+        android:layout_height="104dp"
+        android:src="@drawable/logo_beginvegan"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -8,8 +8,4 @@
 
     <style name="Theme.Beginvegan" parent="Base.Theme.Beginvegan" />
 
-    // 스플래시 스크린
-    <style name="SplashScreen" parent="Theme.AppCompat.NoActionBar">
-        <item name="android:windowBackground">@drawable/logo_beginvegan</item>
-    </style>
 </resources>


### PR DESCRIPTION
## 개요

- 카카오 로그인 이전 Splash 화면수정

## 작업사항

- Splash화면 수정 및 Handler 추가

## 코멘트

- Splash Theme 적용하고 싶었으나 API 31이상만 가능해서 Activity에 Handler추가해서 3초뒤에 자동으로 넘어가도록 설정
